### PR TITLE
feat: Modular Firebase Auth with Email, Google, GitHub

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "node-fetch": "^3.3.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-toastify": "^11.0.5",
         "rss-parser": "^3.13.0",
         "tailwindcss": "^4.1.11"
       },
@@ -2515,6 +2516,15 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/code-block-writer": {
       "version": "10.1.1",
       "dev": true,
@@ -4719,6 +4729,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/readdirp": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "node-fetch": "^3.3.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-toastify": "^11.0.5",
     "rss-parser": "^3.13.0",
     "tailwindcss": "^4.1.11"
   },

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,0 +1,32 @@
+// src/firebase.js
+import { initializeApp } from 'firebase/app';
+import {
+  getAuth,
+  GoogleAuthProvider,
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+  GithubAuthProvider,
+} from 'firebase/auth';
+
+const firebaseConfig = {
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+  appId: import.meta.env.VITE_FIREBASE_APP_ID,
+};
+
+const app = initializeApp(firebaseConfig);
+const auth = getAuth(app);
+const googleProvider = new GoogleAuthProvider();
+const githubProvider = new GithubAuthProvider();
+
+
+export {
+  auth,
+  googleProvider,
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+  githubProvider,
+};


### PR DESCRIPTION
This PR introduces a fully modular authentication system using Firebase Auth
Email & Password Sign In / Register

GitHub Sign-In

Error handling and toast-based feedback

Provider conflict detection (e.g., account already exists with another method)

Setup Instructions for GitHub Auth
To get GitHub Auth working, the repo owner needs to:

Go to: https://github.com/settings/developers → OAuth Apps

Click "New OAuth App" and fill in the details:

Application Name: e.g., MediumPilot

Homepage URL: http://localhost:3000 (for local dev)

Authorization Callback URL: http://localhost:3000 or your deployed URL

Once created, copy:

Client ID

Client Secret

Add it to Firebase Console:

Go to Firebase Console → Authentication → Sign-in method

Enable GitHub

Paste Client ID and Client Secret