### PR TITLE
fix: fixed button CSS

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -181,3 +181,96 @@ button[aria-label],
   border: 1px solid rgba(17, 17, 35, 0.06);
   color: #111827; /* dark text on gold */
 }
+
+.cta-pill {
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  gap: 0.5rem !important;
+  
+  /* Uniform sizing for professional look */
+  padding: 0.75rem 1.5rem !important;
+  min-width: 120px !important;  
+  height: 44px !important; 
+  
+  /* Typography */
+  font-size: 0.95rem !important;
+  font-weight: 600 !important;
+  line-height: 1.2 !important;
+  
+  /* Professional styling */
+  border-radius: 8px !important;
+  border: 1px solid rgba(17, 17, 35, 0.08) !important;
+  cursor: pointer !important;
+  text-decoration: none !important;
+  
+  /* Smooth transitions */
+  transition: all 220ms cubic-bezier(0.2, 0.9, 0.3, 1) !important;
+  transform: translateY(0) !important;
+  will-change: transform, box-shadow !important;
+}
+
+/* Enhanced GitHub Star button styling */
+.lift-star.cta-pill {
+  color: #111827 !important;
+  background: linear-gradient(135deg, #fde047 0%, #facc15 100%) !important; /* Better gold gradient */
+  box-shadow: 
+    0 4px 14px rgba(245, 158, 11, 0.25),
+    0 2px 6px rgba(0, 0, 0, 0.08) !important;
+}
+
+.lift-star.cta-pill:hover {
+  transform: translateY(-4px) scale(1.02) !important;
+  box-shadow: 
+    0 8px 25px rgba(245, 158, 11, 0.35),
+    0 4px 12px rgba(0, 0, 0, 0.12) !important;
+  filter: brightness(1.05) !important;
+}
+
+/* Enhanced Get Demo button styling */
+.lift-getdemo.cta-pill {
+  background: linear-gradient(135deg, #4f46e5 0%, #6366f1 100%) !important;
+  color: white !important;
+  box-shadow: 
+    0 4px 14px rgba(79, 70, 229, 0.25),
+    0 2px 6px rgba(0, 0, 0, 0.08) !important;
+}
+
+.lift-getdemo.cta-pill:hover {
+  transform: translateY(-4px) scale(1.02) !important;
+  background: linear-gradient(135deg, #4338ca 0%, #5b21b6 100%) !important;
+  box-shadow: 
+    0 8px 25px rgba(79, 70, 229, 0.35),
+    0 4px 12px rgba(0, 0, 0, 0.12) !important;
+  filter: brightness(1.05) !important;
+}
+
+/* Active state for both buttons */
+.cta-pill:active {
+  transform: translateY(-2px) scale(1.01) !important;
+  transition-duration: 100ms !important;
+}
+
+/* Focus state for accessibility */
+.cta-pill:focus-visible {
+  outline: 2px solid #4f46e5 !important;
+  outline-offset: 2px !important;
+}
+
+/* Mobile responsive adjustments */
+@media (max-width: 640px) {
+  .cta-pill {
+    min-width: 100px !important;
+    font-size: 0.9rem !important;
+    padding: 0.65rem 1.25rem !important;
+    height: 40px !important;
+  }
+}
+
+/* Force override any conflicting Tailwind classes */
+.lift-star.cta-pill,
+.lift-getdemo.cta-pill {
+  padding: 0.75rem 1.5rem !important;
+  height: 44px !important;
+  min-width: 120px !important;
+}


### PR DESCRIPTION
#  Fix Button Sizing for Professional Navbar Appearance

##  Description

Fixed the sizing inconsistency between the "GitHub Star" button and "Get Demo" button in the navbar. Both buttons now have identical dimensions, professional styling, and enhanced hover effects for a more polished user experience.

**Closes #33**

##  Changes Made

###  Enhanced Button Styling
- **Unified sizing**: Both buttons now have identical height (44px) and minimum width (120px)
- **Professional typography**: Consistent font size (0.95rem) and weight (600) across buttons
- **Improved gradients**: Enhanced gold gradient for GitHub Star and indigo gradient for Get Demo
- **Smooth animations**: Added lift and glow effects on hover with cubic-bezier transitions

###  Mobile Responsiveness  
- **Responsive design**: Buttons automatically resize on mobile devices (height: 40px, smaller padding)
- **Touch-friendly**: Maintained accessible button sizes for mobile interactions

###  Visual Enhancements
- **Consistent spacing**: Uniform padding (0.75rem 1.5rem) and gap (0.5rem) between elements
- **Professional shadows**: Added subtle box-shadow effects with brand-appropriate glows
- **Better accessibility**: Enhanced focus states with visible outlines for keyboard navigation

##  Visual Changes

### Before
- ❌ Buttons had different sizes and inconsistent styling
- ❌ Unprofessional appearance with misaligned elements
- ❌ Basic hover effects

### After  
- ✅ Identical button dimensions and professional appearance
- ✅ Consistent typography and spacing throughout
- ✅ Smooth hover animations with lift and glow effects
- ✅ Mobile-responsive design

##  Testing

### Manual Testing Completed
- [x] **Desktop**: Verified identical button sizes across different screen widths
- [x] **Mobile**: Confirmed responsive behavior on mobile devices (320px-768px)
- [x] **Hover Effects**: Tested smooth animations and visual feedback
- [x] **Accessibility**: Verified keyboard navigation and focus states
- [x] **Cross-browser**: Tested on Chrome, Firefox, and Safari