### PR TITLE
Removing Image Background from community page

### DIFF
--- a/src/pages/CommunityCard.jsx
+++ b/src/pages/CommunityCard.jsx
@@ -142,10 +142,7 @@ export default function CommunityCard({
             transformStyle: 'preserve-3d',
             background: isHovered
               ? 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)'
-              : 'linear-gradient(135deg, #f3f4f6 0%, #e5e7eb 100%)',
-            boxShadow: isHovered
-              ? '0 10px 30px rgba(102, 126, 234, 0.4), inset 0 2px 4px rgba(255, 255, 255, 0.2)'
-              : '0 4px 10px rgba(0, 0, 0, 0.05)',
+              : 'linear-gradient(135deg, #fff 0%, #fff 100%)',
           }}
         >
           {/* Inner glow for icon */}

--- a/src/pages/CommunityCard.jsx
+++ b/src/pages/CommunityCard.jsx
@@ -136,10 +136,6 @@ export default function CommunityCard({
           className="relative w-16 h-16 flex items-center justify-center rounded-2xl mb-6 overflow-hidden
                      transform transition-all duration-500 group-hover:scale-110"
           style={{
-            transform: isHovered
-              ? `translateZ(40px) rotateZ(${mousePosition.x * 10}deg) scale(1.1)`
-              : 'translateZ(0px) rotateZ(0deg) scale(1)',
-            transformStyle: 'preserve-3d',
             background: isHovered
               ? 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)'
               : 'linear-gradient(135deg, #fff 0%, #fff 100%)',
@@ -176,12 +172,8 @@ export default function CommunityCard({
                 : 'none',
             }}
           >
-            {img == githubLogo ? (
-              <img className="bg-gray-200" src={img} alt="" />
-            ) : (
-              <img src={img} alt="" />
-            )}
-          </div>
+              <img src={img} alt=""/>
+            </div>
         </div>
 
         {/* Feature title with animated gradient */}


### PR DESCRIPTION
- Fix for #78 
- I tried to remove the image background from the icons and this what I could do from what I could understand from the issue.
- Also removed the 3D transform effect when hovering that was applied to the icons
# Screenshot
<img width="1726" height="883" alt="image" src="https://github.com/user-attachments/assets/2d55aeea-6d6a-492f-8746-ec70a8533f70" />
