### PR TITLE
Add normal and hover logout icons with dashboard hover swap

### DIFF
--- a/src/assets/icons/logout-hover.svg
+++ b/src/assets/icons/logout-hover.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="800px" height="800px" viewBox="0 0 24 24" id="logout-hover" data-name="Flat Color" xmlns="http://www.w3.org/2000/svg" class="icon flat-color">
+  <path id="secondary" d="M13,5H7A2,2,0,0,0,5,7V17a2,2,0,0,0,2,2h6a1,1,0,0,0,0-2H7V7h6a1,1,0,0,0,0-2Z" style="fill: rgb(79, 70, 229);"></path>
+  <path id="primary" d="M21.71,11.29l-3-3a1,1,0,0,0-1.42,1.42L18.59,11H11a1,1,0,0,0,0,2h7.59l-1.3,1.29a1,1,0,1,0,1.42,1.42l3-3A1,1,0,0,0,21.71,11.29Z" style="fill: rgb(17, 24, 39);"></path>
+</svg>

--- a/src/assets/icons/logout.svg
+++ b/src/assets/icons/logout.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="800px" height="800px" viewBox="0 0 24 24" id="logout" data-name="Flat Color" xmlns="http://www.w3.org/2000/svg" class="icon flat-color">
+  <path id="secondary" d="M13,5H7A2,2,0,0,0,5,7V17a2,2,0,0,0,2,2h6a1,1,0,0,0,0-2H7V7h6a1,1,0,0,0,0-2Z" style="fill: rgb(44, 169, 188);"></path>
+  <path id="primary" d="M21.71,11.29l-3-3a1,1,0,0,0-1.42,1.42L18.59,11H11a1,1,0,0,0,0,2h7.59l-1.3,1.29a1,1,0,1,0,1.42,1.42l3-3A1,1,0,0,0,21.71,11.29Z" style="fill: rgb(0, 0, 0);"></path>
+</svg>

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -15,6 +15,8 @@ import React, { useEffect, useState } from 'react';
 import { signOut } from 'firebase/auth';
 import { auth } from '../firebase';
 import logo from '../assets/mediumpilot.svg';
+import LogoutIcon from '../assets/icons/logout.svg';
+import LogoutHoverIcon from '../assets/icons/logout-hover.svg';
 
 /**
  * Dashboard Page Component
@@ -226,9 +228,23 @@ export default function Dashboard({ user }) {
             <h1 className="text-4xl font-bold mb-4">MediumPilot</h1>
             <button
               onClick={() => signOut(auth)}
-              className="border-2 border-white text-white hover:bg-white hover:text-indigo-600 font-medium py-3 px-8 rounded-full transition-colors"
+              className="group inline-flex items-center justify-center border-2 border-white text-white hover:bg-white hover:text-indigo-600 font-medium py-3 px-8 rounded-full transition-colors"
             >
-              Sign Out
+              <span className="relative w-5 h-5 mr-2">
+                <img
+                  src={LogoutIcon}
+                  alt=""
+                  aria-hidden="true"
+                  className="absolute inset-0 w-5 h-5 opacity-100 group-hover:opacity-0 transition-opacity duration-200"
+                />
+                <img
+                  src={LogoutHoverIcon}
+                  alt=""
+                  aria-hidden="true"
+                  className="absolute inset-0 w-5 h-5 opacity-0 group-hover:opacity-100 transition-opacity duration-200"
+                />
+              </span>
+              <span>Sign Out</span>
             </button>
             {/* Status message */}
             {status && (


### PR DESCRIPTION
Fixes #109

## Summary
This PR resolves the logout icon UI issue by introducing two dedicated icon assets for the `Sign Out` button in `Dashboard.jsx`:

- Normal state icon (hover out)
- Hover state icon (hover in)

The hover icon was also adjusted to stay visible against the button’s white hover background.

## Changes Made
- Added new icon assets:
  - `src/assets/icons/logout.svg`
  - `src/assets/icons/logout-hover.svg`
- Updated `src/pages/Dashboard.jsx`:
  - Imported both logout icons
  - Added icon swap behavior using hover state (`group-hover`)
  - Kept existing sign-out functionality intact

## UI Behavior
- Default: normal logout icon is shown
- On hover: normal icon fades out, hover icon fades in
- Hover icon remains visible (no white-on-white disappearance)

## Testing
- Ran app locally with `npm run dev`
- Navigated to Dashboard
- Verified:
  - Normal icon appears by default
  - Hover icon appears on hover

<img width="1129" height="497" alt="Screenshot 2026-02-17 221334" src="https://github.com/user-attachments/assets/2696aef1-ae61-4b2e-8354-075d956670eb" />
<br>
<img width="1123" height="478" alt="Screenshot 2026-02-17 221346" src="https://github.com/user-attachments/assets/1281196b-8956-4c4b-a982-2feaa51e4a3e" />
